### PR TITLE
read csv as utf8

### DIFF
--- a/jobfunnel/jobfunnel.py
+++ b/jobfunnel/jobfunnel.py
@@ -148,7 +148,7 @@ class JobFunnel(object):
 
     def read_csv(self, path, key_by_id=True):
         # reads csv passed in as path
-        with open(path, 'r') as csvfile:
+        with open(path, 'r', encoding='utf8', errors='ignore') as csvfile:
             reader = csv.DictReader(csvfile)
             if key_by_id:
                 return dict([(j['id'], j) for j in reader])


### PR DESCRIPTION
## Description
Had this error: UnicodeDecodeError: 'utf-8' codec can't decode, if the csv file is not saved in utf-8.
Fix: force to read the existing csv file in encoding utf-8

Changed L151 from:
with open(path, 'r') as csvfile:
to:
with open(path, 'r', encoding='utf8', errors='ignore') as csvfile:

## Type of change

Please mark any boxes that apply.

- [ Yes] Bug fix (non-breaking change which fixes an issue)
- [ No] New feature (non-breaking change which adds functionality)
- [ No] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ No] This change requires a documentation update

## How Has This Been Tested?

Before:
- step1. read the result csv file in Excel (for example), the csv can be saved as non utf-8 encoding (e.g. Montréal)
- step2. update the result, get this: UnicodeDecodeError: 'utf-8' codec can't decode...
After fix:
Able to read csv file saved by Excel
## Checklist:

Please mark any boxes that have been completed.

- [ x] I have performed a self-review of my own code.
- [x ] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
