### PR TITLE
Glassdoor Dynamic/Static Switching

### DIFF
--- a/demo/settings.yaml
+++ b/demo/settings.yaml
@@ -6,10 +6,10 @@ output_path: './'
 # providers from which to search (case insensitive)
 providers:
 
-  - 'GlassDoorDynamic'
   - 'Indeed'
-  # - 'Monster'
-  # - 'GlassDoorStatic'
+  - 'Monster'
+  - 'GlassDoorStatic'
+  # - 'GlassDoorDynamic'
 
 # filters
 search_terms:

--- a/demo/settings.yaml
+++ b/demo/settings.yaml
@@ -5,9 +5,11 @@ output_path: './'
 
 # providers from which to search (case insensitive)
 providers:
-        #- 'GlassDoor' 
+
+  - 'GlassDoorDynamic'
   - 'Indeed'
-  - 'Monster'
+  # - 'Monster'
+  # - 'GlassDoorStatic'
 
 # filters
 search_terms:

--- a/jobfunnel/__main__.py
+++ b/jobfunnel/__main__.py
@@ -15,6 +15,8 @@ from .glassdoor_base import GlassDoorBase
 from .glassdoor_dynamic import GlassDoorDynamic
 from .glassdoor_static import GlassDoorStatic
 
+# TODO: Test GlassdoorDynamic Provider
+
 PROVIDERS = {
     'indeed': Indeed,
     'monster': Monster,

--- a/jobfunnel/__main__.py
+++ b/jobfunnel/__main__.py
@@ -15,8 +15,6 @@ from .glassdoor_base import GlassDoorBase
 from .glassdoor_dynamic import GlassDoorDynamic
 from .glassdoor_static import GlassDoorStatic
 
-# TODO: Test GlassdoorDynamic Provider
-
 PROVIDERS = {
     'indeed': Indeed,
     'monster': Monster,

--- a/jobfunnel/config/settings.yaml
+++ b/jobfunnel/config/settings.yaml
@@ -9,7 +9,8 @@ output_path: 'search'
 providers:
   - 'Indeed'
   - 'Monster'
-  # - 'GlassDoor'
+  # - 'GlassDoorDynamic'
+  - 'GlassDoorStatic'
 
 # filters
 search_terms:

--- a/jobfunnel/config/settings.yaml
+++ b/jobfunnel/config/settings.yaml
@@ -7,10 +7,11 @@ output_path: 'search'
 
 # providers from which to search (case insensitive)
 providers:
+  - 'GlassDoorStatic'
   - 'Indeed'
   - 'Monster'
-  # - 'GlassDoorDynamic'
-  - 'GlassDoorStatic'
+
+
 
 # filters
 search_terms:

--- a/jobfunnel/config/valid_options.py
+++ b/jobfunnel/config/valid_options.py
@@ -29,10 +29,10 @@ CONFIG_TYPES = {
         'ip_address': [str],
         'port': [str]
     },
-    'max_listing_days': [int]
+    'max_listing_days': [int],
 
 }
 
-PROVIDERS = ['glassdoor', 'indeed', 'monster']
+PROVIDERS = ['glassdoordynamic', 'glassdoorstatic', 'indeed', 'monster']
 DOMAINS = ['com', 'ca']
 DELAY_FUN = ['constant', 'linear', 'sigmoid']

--- a/jobfunnel/glassdoor_base.py
+++ b/jobfunnel/glassdoor_base.py
@@ -1,0 +1,88 @@
+import re
+
+from bs4 import BeautifulSoup
+from concurrent.futures import ThreadPoolExecutor, wait
+from logging import info as log_info
+from math import ceil
+from requests import post
+from time import sleep, time
+
+from .jobfunnel import JobFunnel, MASTERLIST_HEADER
+from .tools.tools import filter_non_printables
+from .tools.tools import post_date_from_relative_post_age
+
+
+class GlassDoorBase(JobFunnel):
+    def __init__(self, args):
+        super().__init__(args)
+        self.provider = 'glassdoorbase'
+        self.max_results_per_page = 30
+        self.delay = 0
+
+        self.location_headers = {
+            'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,'
+            'image/webp,*/*;q=0.01',
+            'accept-encoding': 'gzip, deflate, sdch, br',
+            'accept-language': 'en-GB,en-US;q=0.8,en;q=0.6',
+            'referer': 'https://www.glassdoor.{0}/'.format(
+                self.search_terms['region']['domain']
+            ),
+            'upgrade-insecure-requests': '1',
+            'user-agent': self.user_agent,
+            'Cache-Control': 'no-cache',
+            'Connection': 'keep-alive',
+        }
+        self.query = '-'.join(self.search_terms['keywords'])
+
+    def convert_radius(self, radius):
+        """function that quantizes the user input radius to a valid radius
+           value: 10, 20, 30, 50, 100, and 200 kilometers"""
+        if self.search_terms['region']['domain'] == 'com':
+            if radius < 5:
+                radius = 0
+            elif 5 <= radius < 10:
+                radius = 5
+            elif 10 <= radius < 15:
+                radius = 10
+            elif 15 <= radius < 25:
+                radius = 15
+            elif 25 <= radius < 50:
+                radius = 25
+            elif 50 <= radius < 100:
+                radius = 50
+            elif 100 <= radius:
+                radius = 100
+            return radius
+
+        else:
+            if radius < 10:
+                radius = 0
+            elif 10 <= radius < 20:
+                radius = 10
+            elif 20 <= radius < 30:
+                radius = 20
+            elif 30 <= radius < 50:
+                radius = 30
+            elif 50 <= radius < 100:
+                radius = 50
+            elif 100 <= radius < 200:
+                radius = 100
+            elif radius >= 200:
+                radius = 200
+
+        glassdoor_radius = {0: 0, 10: 6, 20: 12,
+                            30: 19, 50: 31, 100: 62, 200: 124}
+
+        return glassdoor_radius[radius]
+
+    def parse_blurb(self, job, html):
+        """parses and stores job description into dict entry"""
+        job_link_soup = BeautifulSoup(html, self.bs4_parser)
+
+        try:
+            job['blurb'] = job_link_soup.find(
+                id='JobDescriptionContainer').text.strip()
+        except AttributeError:
+            job['blurb'] = ''
+
+        filter_non_printables(job)

--- a/jobfunnel/glassdoor_dynamic.py
+++ b/jobfunnel/glassdoor_dynamic.py
@@ -16,6 +16,8 @@ from .glassdoor_base import GlassDoorBase
 
 
 class GlassDoorDynamic(GlassDoorBase):
+    """The Dynamic Version of the GlassDoor scraper, that uses selenium to scrape job postings."""
+
     def __init__(self, args):
         super().__init__(args)
         self.provider = 'glassdoordynamic'

--- a/jobfunnel/glassdoor_dynamic.py
+++ b/jobfunnel/glassdoor_dynamic.py
@@ -12,112 +12,50 @@ from time import sleep, time
 from .jobfunnel import JobFunnel, MASTERLIST_HEADER
 from .tools.tools import filter_non_printables
 from .tools.tools import post_date_from_relative_post_age, get_webdriver
+from .glassdoor_base import GlassDoorBase
 
 
-class GlassDoor(JobFunnel):
-
+class GlassDoorDynamic(GlassDoorBase):
     def __init__(self, args):
         super().__init__(args)
-        self.provider = 'glassdoor'
-        self.max_results_per_page = 30
-        self.delay = 0
-        self.location_headers = {
-            'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,'
-                      'image/webp,*/*;q=0.01',
-            'accept-encoding': 'gzip, deflate, sdch, br',
-            'accept-language': 'en-GB,en-US;q=0.8,en;q=0.6',
-            'referer': 'https://www.glassdoor.{0}/'.format(
-                self.search_terms['region']['domain']),
-            'upgrade-insecure-requests': '1',
-            'user-agent': self.user_agent,
-            'Cache-Control': 'no-cache',
-            'Connection': 'keep-alive'
-        }
-        self.query = '-'.join(self.search_terms['keywords'])
+        self.provider = 'glassdoordynamic'
 
         # initialize the webdriver
         self.driver = get_webdriver()
 
-    def convert_radius(self, radius):
-        """function that quantizes the user input radius to a valid radius
-           value: 10, 20, 30, 50, 100, and 200 kilometers"""
-        if self.search_terms['region']['domain'] == 'com':
-            if radius < 5:
-                radius = 0
-            elif 5 <= radius < 10:
-                radius = 5
-            elif 10 <= radius < 15:
-                radius = 10
-            elif 15 <= radius < 25:
-                radius = 15
-            elif 25 <= radius < 50:
-                radius = 25
-            elif 50 <= radius < 100:
-                radius = 50
-            elif 100 <= radius:
-                radius = 100
-            return radius
-
-        else:
-            if radius < 10:
-                radius = 0
-            elif 10 <= radius < 20:
-                radius = 10
-            elif 20 <= radius < 30:
-                radius = 20
-            elif 30 <= radius < 50:
-                radius = 30
-            elif 50 <= radius < 100:
-                radius = 50
-            elif 100 <= radius < 200:
-                radius = 100
-            elif radius >= 200:
-                radius = 200
-
-        glassdoor_radius = {
-            0: 0,
-            10: 6,
-            20: 12,
-            30: 19,
-            50: 31,
-            100: 62,
-            200: 124
-        }
-
-        return glassdoor_radius[radius]
-
     def get_search_url(self, method='get'):
         """gets the glassdoor search url"""
         # form the location lookup request data
-        data = {
-            'term': self.search_terms['region']['city'],
-            'maxLocationsToReturn': 10
-        }
+        data = {'term': self.search_terms['region']
+                ['city'], 'maxLocationsToReturn': 10}
 
         # form the location lookup url
-        location_url = \
-            'https://www.glassdoor.co.in/findPopularLocationAjax.htm?'
+        location_url = 'https://www.glassdoor.co.in/findPopularLocationAjax.htm?'
 
         # get the location id for search location
-        location_response = \
-            self.s.post(location_url, headers=self.location_headers,
-                        data=data).json()
+        location_response = self.s.post(
+            location_url, headers=self.location_headers, data=data
+        ).json()
 
         if method == 'get':
             # form job search url
-            search = ('https://www.glassdoor.{0}/Job/jobs.htm?'
-                      'clickSource=searchBtn&sc.keyword={1}&locT=C&locId={2}&jobType=&radius={3}'.format(
-                          self.search_terms['region']['domain'],
-                          self.query,
-                          location_response[0]['locationId'],
-                          self.convert_radius(
-                              self.search_terms['region']['radius'])))
+            search = (
+                'https://www.glassdoor.{0}/Job/jobs.htm?'
+                'clickSource=searchBtn&sc.keyword={1}&locT=C&locId={2}&jobType=&radius={3}'.format(
+                    self.search_terms['region']['domain'],
+                    self.query,
+                    location_response[0]['locationId'],
+                    self.convert_radius(self.search_terms['region']['radius']),
+                )
+            )
 
             return search
         elif method == 'post':
             # form the job search url
-            search = (f"https://www.glassdoor."
-                      f"{self.search_terms['region']['domain']}/Job/jobs.htm")
+            search = (
+                f'https://www.glassdoor.'
+                f"{self.search_terms['region']['domain']}/Job/jobs.htm"
+            )
 
             # form the job search data
             data = {
@@ -126,8 +64,7 @@ class GlassDoor(JobFunnel):
                 'locT': 'C',
                 'locId': location_response[0]['locationId'],
                 'jobType': '',
-                'radius': self.convert_radius(
-                    self.search_terms['region']['radius'])
+                'radius': self.convert_radius(self.search_terms['region']['radius']),
             }
 
             return search, data
@@ -139,9 +76,9 @@ class GlassDoor(JobFunnel):
         log_info(f'getting glassdoor page {page} : {url}')
 
         self.driver.get(url)
-        job = BeautifulSoup(
-            self.driver.page_source, self.bs4_parser).\
-            find_all('li', attrs={'class', 'jl'})
+        job = BeautifulSoup(self.driver.page_source, self.bs4_parser).find_all(
+            'li', attrs={'class', 'jl'}
+        )
         job_soup_list.extend(job)
 
     def search_joblink_for_blurb(self, job):
@@ -150,8 +87,7 @@ class GlassDoor(JobFunnel):
         log_info(f'getting glassdoor search: {search}')
 
         self.driver.get(search)
-        job_link_soup = BeautifulSoup(
-            self.driver.page_source, self.bs4_parser)
+        job_link_soup = BeautifulSoup(self.driver.page_source, self.bs4_parser)
 
         try:
             job['blurb'] = job_link_soup.find(
@@ -174,18 +110,6 @@ class GlassDoor(JobFunnel):
         res = self.driver.page_source
         return job, res
 
-    def parse_blurb(self, job, html):
-        """parses and stores job description into dict entry"""
-        job_link_soup = BeautifulSoup(html, self.bs4_parser)
-
-        try:
-            job['blurb'] = job_link_soup.find(
-                id='JobDescriptionContainer').text.strip()
-        except AttributeError:
-            job['blurb'] = ''
-
-        filter_non_printables(job)
-
     def scrape(self):
         """function that scrapes job posting from glassdoor and pickles it"""
         log_info(f'jobfunnel glassdoor to pickle running @ {self.date_string}')
@@ -195,27 +119,30 @@ class GlassDoor(JobFunnel):
 
         # get the html data, initialize bs4 with lxml
         self.driver.get(search)
-        print("It's very likely that Glassdoor might require you to fill out a CAPTCHA form. Follow these steps if it does ask you to complete a CAPTCHA:"
-              "\n 1.Refresh the glassdoor site in the new browser window that just popped up.\n" " 2.Then complete the CAPTCHA in the browser.\n 3.Press Enter to continue")
+        print(
+            "It's very likely that Glassdoor might require you to fill out a CAPTCHA form. Follow these steps if it does ask you to complete a CAPTCHA: "
+            '\n 1.Refresh the glassdoor site in the new browser window that just popped up.\n'
+            ' 2.Then complete the CAPTCHA in the browser.\n 3.Press Enter to continue'
+        )
         # wait for user to complete CAPTCHA
         input()
 
         # create the soup base
         soup_base = BeautifulSoup(self.driver.page_source, self.bs4_parser)
-        num_res = soup_base.find('p', attrs={
-            'class', 'jobsCount'})
-        while(num_res is None):
-            print('Looks like something went wrong. \nMake sure you complete the CAPTCHA in the new browser window that just popped up. Try refreshing the page and attempt to complete the CAPTCHA again. ')
+        num_res = soup_base.find('p', attrs={'class', 'jobsCount'})
+        while num_res is None:
+            print(
+                'Looks like something went wrong. \nMake sure you complete the CAPTCHA in the new browser window that just popped up. Try refreshing the page and attempt to complete the CAPTCHA again. '
+            )
             input()
             soup_base = BeautifulSoup(self.driver.page_source, self.bs4_parser)
-            num_res = soup_base.find('p', attrs={
-                'class', 'jobsCount'})
+            num_res = soup_base.find('p', attrs={'class', 'jobsCount'})
         # scrape total number of results, and calculate the # pages needed
 
         num_res = num_res.text.strip()
         num_res = int(re.findall(r'(\d+)', num_res.replace(',', ''))[0])
-        log_info(f'Found {num_res} glassdoor results for query='
-                 f'{self.query}')
+        log_info(
+            f'Found {num_res} glassdoor results for query=' f'{self.query}')
 
         pages = int(ceil(num_res / self.max_results_per_page))
 
@@ -230,22 +157,33 @@ class GlassDoor(JobFunnel):
         for page in range(1, pages + 1):
             if page == 1:
                 fts.append(  # append thread job future to futures list
-                    threads.submit(self.search_page_for_job_soups,
-                                   page, self.driver.current_url, job_soup_list)
+                    threads.submit(
+                        self.search_page_for_job_soups,
+                        page,
+                        self.driver.current_url,
+                        job_soup_list,
+                    )
                 )
             else:
                 # gets partial url for next page
-                part_url = soup_base.find('li', attrs={
-                    'class', 'next'}).find('a').get('href')
+                part_url = (
+                    soup_base.find('li', attrs={'class', 'next'}).find(
+                        'a').get('href')
+                )
                 # uses partial url to construct next page url
-                page_url = re.sub(r".htm", "IP" + str(page) + ".htm",
-                                  f"https://www.glassdoor."
-                                  f"{self.search_terms['region']['domain']}"
-                                  f"{part_url}")
+                page_url = re.sub(
+                    r'.htm',
+                    'IP' + str(page) + '.htm',
+                    f'https://www.glassdoor.'
+                    f"{self.search_terms['region']['domain']}"
+                    f'{part_url}',
+                )
 
                 fts.append(  # append thread job future to futures list
-                    threads.submit(self.search_page_for_job_soups,
-                                   page, page_url, job_soup_list))
+                    threads.submit(
+                        self.search_page_for_job_soups, page, page_url, job_soup_list
+                    )
+                )
         wait(fts)  # wait for all scrape jobs to finish
         # close and shutdown the web driver
         self.driver.close()
@@ -259,9 +197,11 @@ class GlassDoor(JobFunnel):
             try:
                 # jobs should at minimum have a title, company and location
                 job['title'] = s.find_all('a', attrs={'class', 'jobTitle'})[
-                    1].text.strip()
+                    1
+                ].text.strip()
                 job['company'] = s.find(
-                    'div', attrs={'class', 'jobEmpolyerName'}).text.strip()
+                    'div', attrs={'class', 'jobEmpolyerName'}
+                ).text.strip()
                 job['location'] = s.find(
                     'span', attrs={'class', 'loc'}).text.strip()
             except AttributeError:
@@ -272,21 +212,27 @@ class GlassDoor(JobFunnel):
 
             try:
                 labels = s.find_all('div', attrs={'class', 'jobLabel'})
-                job['tags'] = "\n".join([l.text.strip() for l in labels
-                                         if l.text.strip() != 'New'])
+                job['tags'] = '\n'.join(
+                    [l.text.strip() for l in labels if l.text.strip() != 'New']
+                )
             except AttributeError:
                 job['tags'] = ''
 
             try:
-                job['date'] = s.find('div', attrs={'class', 'jobLabels'}).find(
-                    'span', attrs={'class', 'jobLabel nowrap'}).text.strip()
+                job['date'] = (
+                    s.find('div', attrs={'class', 'jobLabels'})
+                    .find('span', attrs={'class', 'jobLabel nowrap'})
+                    .text.strip()
+                )
             except AttributeError:
                 job['date'] = ''
 
             try:
                 job['id'] = s.get('data-id')
-                job['link'] = s.find('div', attrs={
-                    'class', 'logoWrap'}).find('a').get('href')
+                job['link'] = (
+                    s.find('div', attrs={'class', 'logoWrap'}).find(
+                        'a').get('href')
+                )
 
             except (AttributeError, IndexError):
                 job['id'] = ''
@@ -310,8 +256,9 @@ class GlassDoor(JobFunnel):
         # checks if delay is set or not, then extracts blurbs from job links
         if self.delay_config is not None:
             # calls super class to run delay specific threading logic
-            super().delay_threader(scrape_list, self.get_blurb_with_delay,
-                                   self.parse_blurb, threads)
+            super().delay_threader(
+                scrape_list, self.get_blurb_with_delay, self.parse_blurb, threads
+            )
 
         else:  # maps jobs to threads and cleans them up when done
             # start time recording

--- a/jobfunnel/glassdoor_static.py
+++ b/jobfunnel/glassdoor_static.py
@@ -16,83 +16,83 @@ from .glassdoor_base import GlassDoorBase
 class GlassDoorStatic(GlassDoorBase):
     def __init__(self, args):
         super().__init__(args)
-        self.provider = "glassdoorstatic"
+        self.provider = 'glassdoorstatic'
         self.headers = {
-            "accept": "text/html,application/xhtml+xml,application/xml;"
-            "q=0.9,image/webp,*/*;q=0.8",
-            "accept-encoding": "gzip, deflate, sdch, br",
-            "accept-language": "en-GB,en-US;q=0.8,en;q=0.6",
-            "referer": "https://www.glassdoor.{0}/".format(
-                self.search_terms["region"]["domain"]
+            'accept': 'text/html,application/xhtml+xml,application/xml;'
+            'q=0.9,image/webp,*/*;q=0.8',
+            'accept-encoding': 'gzip, deflate, sdch, br',
+            'accept-language': 'en-GB,en-US;q=0.8,en;q=0.6',
+            'referer': 'https://www.glassdoor.{0}/'.format(
+                self.search_terms['region']['domain']
             ),
-            "upgrade-insecure-requests": "1",
-            "user-agent": self.user_agent,
-            "Cache-Control": "no-cache",
-            "Connection": "keep-alive",
+            'upgrade-insecure-requests': '1',
+            'user-agent': self.user_agent,
+            'Cache-Control': 'no-cache',
+            'Connection': 'keep-alive',
         }
 
-    def get_search_url(self, method="get"):
+    def get_search_url(self, method='get'):
         """gets the glassdoor search url"""
         # form the location lookup request data
-        data = {"term": self.search_terms["region"]
-                ["city"], "maxLocationsToReturn": 10}
+        data = {'term': self.search_terms['region']
+                ['city'], 'maxLocationsToReturn': 10}
 
         # form the location lookup url
-        location_url = "https://www.glassdoor.co.in/findPopularLocationAjax.htm?"
+        location_url = 'https://www.glassdoor.co.in/findPopularLocationAjax.htm?'
 
         # get the location id for search location
         location_response = self.s.post(
             location_url, headers=self.location_headers, data=data
         ).json()
 
-        if method == "get":
+        if method == 'get':
             # @TODO implement get style for glassdoor
             raise NotImplementedError()
-        elif method == "post":
+        elif method == 'post':
             # form the job search url
             search = (
-                f"https://www.glassdoor."
+                f'https://www.glassdoor.'
                 f"{self.search_terms['region']['domain']}/Job/jobs.htm"
             )
 
             # form the job search data
             data = {
-                "clickSource": "searchBtn",
-                "sc.keyword": self.query,
-                "locT": "C",
-                "locId": location_response[0]["locationId"],
-                "jobType": "",
-                "radius": self.convert_radius(self.search_terms["region"]["radius"]),
+                'clickSource': 'searchBtn',
+                'sc.keyword': self.query,
+                'locT': 'C',
+                'locId': location_response[0]['locationId'],
+                'jobType': '',
+                'radius': self.convert_radius(self.search_terms['region']['radius']),
             }
 
             return search, data
         else:
-            raise ValueError(f"No html method {method} exists")
+            raise ValueError(f'No html method {method} exists')
 
     def search_page_for_job_soups(self, data, page, url, job_soup_list):
         """function that scrapes the glassdoor page for a list of job soups"""
-        log_info(f"getting glassdoor page {page} : {url}")
+        log_info(f'getting glassdoor page {page} : {url}')
 
         job = BeautifulSoup(
             self.s.post(url, headers=self.headers,
                         data=data).text, self.bs4_parser
-        ).find_all("li", attrs={"class", "jl"})
+        ).find_all('li', attrs={'class', 'jl'})
         job_soup_list.extend(job)
 
     def search_joblink_for_blurb(self, job):
         """function that scrapes the glassdoor job link for the blurb"""
-        search = job["link"]
-        log_info(f"getting glassdoor search: {search}")
+        search = job['link']
+        log_info(f'getting glassdoor search: {search}')
         job_link_soup = BeautifulSoup(
             self.s.post(
                 search, headers=self.location_headers).text, self.bs4_parser
         )
 
         try:
-            job["blurb"] = job_link_soup.find(
-                id="JobDescriptionContainer").text.strip()
+            job['blurb'] = job_link_soup.find(
+                id='JobDescriptionContainer').text.strip()
         except AttributeError:
-            job["blurb"] = ""
+            job['blurb'] = ''
 
         filter_non_printables(job)
 
@@ -102,18 +102,18 @@ class GlassDoorStatic(GlassDoorBase):
         """gets blurb from glassdoor job link and sets delays for requests"""
         sleep(delay)
 
-        search = job["link"]
-        log_info(f"delay of {delay:.2f}s, getting glassdoor search: {search}")
+        search = job['link']
+        log_info(f'delay of {delay:.2f}s, getting glassdoor search: {search}')
 
         res = self.s.post(search, headers=self.location_headers).text
         return job, res
 
     def scrape(self):
         """function that scrapes job posting from glassdoor and pickles it"""
-        log_info(f"jobfunnel glassdoor to pickle running @ {self.date_string}")
+        log_info(f'jobfunnel glassdoor to pickle running @ {self.date_string}')
 
         # get the search url and data
-        search, data = self.get_search_url(method="post")
+        search, data = self.get_search_url(method='post')
 
         # get the html data, initialize bs4 with lxml
         request_html = self.s.post(search, headers=self.headers, data=data)
@@ -123,10 +123,10 @@ class GlassDoorStatic(GlassDoorBase):
 
         # scrape total number of results, and calculate the # pages needed
         num_res = soup_base.find(
-            "p", attrs={"class", "jobsCount"}).text.strip()
-        num_res = int(re.findall(r"(\d+)", num_res.replace(",", ""))[0])
+            'p', attrs={'class', 'jobsCount'}).text.strip()
+        num_res = int(re.findall(r'(\d+)', num_res.replace(',', ''))[0])
         log_info(
-            f"Found {num_res} glassdoor results for query=" f"{self.query}")
+            f'Found {num_res} glassdoor results for query=' f'{self.query}')
 
         pages = int(ceil(num_res / self.max_results_per_page))
 
@@ -152,16 +152,16 @@ class GlassDoorStatic(GlassDoorBase):
             else:
                 # gets partial url for next page
                 part_url = (
-                    soup_base.find("li", attrs={"class", "next"}).find(
-                        "a").get("href")
+                    soup_base.find('li', attrs={'class', 'next'}).find(
+                        'a').get('href')
                 )
                 # uses partial url to construct next page url
                 page_url = re.sub(
-                    r"_IP\d+\.",
-                    "_IP" + str(page) + ".",
-                    f"https://www.glassdoor."
+                    r'_IP\d+\.',
+                    '_IP' + str(page) + '.',
+                    f'https://www.glassdoor.'
                     f"{self.search_terms['region']['domain']}"
-                    f"{part_url}",
+                    f'{part_url}',
                 )
 
                 fts.append(  # append thread job future to futures list
@@ -178,69 +178,69 @@ class GlassDoorStatic(GlassDoorBase):
         # make a dict of job postings from the listing briefs
         for s in job_soup_list:
             # init dict to store scraped data
-            job = dict([(k, "") for k in MASTERLIST_HEADER])
+            job = dict([(k, '') for k in MASTERLIST_HEADER])
 
             # scrape the post data
-            job["status"] = "new"
+            job['status'] = 'new'
             try:
                 # jobs should at minimum have a title, company and location
-                job["title"] = (
-                    s.find("div", attrs={"class", "jobContainer"})
+                job['title'] = (
+                    s.find('div', attrs={'class', 'jobContainer'})
                     .find(
-                        "a",
-                        attrs={"class", "jobLink jobInfoItem jobTitle"},
+                        'a',
+                        attrs={'class', 'jobLink jobInfoItem jobTitle'},
                         recursive=False,
                     )
                     .text.strip()
                 )
-                job["company"] = s.find(
-                    "div", attrs={"class", "jobInfoItem jobEmpolyerName"}
+                job['company'] = s.find(
+                    'div', attrs={'class', 'jobInfoItem jobEmpolyerName'}
                 ).text.strip()
-                job["location"] = s.get("data-job-loc")
+                job['location'] = s.get('data-job-loc')
             except AttributeError:
                 continue
 
             # set blurb to none for now
-            job["blurb"] = ""
+            job['blurb'] = ''
 
             try:
-                labels = s.find_all("div", attrs={"class", "jobLabel"})
-                job["tags"] = "\n".join(
-                    [l.text.strip() for l in labels if l.text.strip() != "New"]
+                labels = s.find_all('div', attrs={'class', 'jobLabel'})
+                job['tags'] = '\n'.join(
+                    [l.text.strip() for l in labels if l.text.strip() != 'New']
                 )
             except AttributeError:
-                job["tags"] = ""
+                job['tags'] = ''
 
             try:
-                job["date"] = (
-                    s.find("div", attrs={"class", "jobLabels"})
-                    .find("span", attrs={"class", "jobLabel nowrap"})
+                job['date'] = (
+                    s.find('div', attrs={'class', 'jobLabels'})
+                    .find('span', attrs={'class', 'jobLabel nowrap'})
                     .text.strip()
                 )
             except AttributeError:
-                job["date"] = ""
+                job['date'] = ''
 
             try:
                 part_url = (
-                    s.find("div", attrs={"class", "logoWrap"}).find(
-                        "a").get("href")
+                    s.find('div', attrs={'class', 'logoWrap'}).find(
+                        'a').get('href')
                 )
-                job["id"] = s.get("data-id")
-                job["link"] = (
-                    f"https://www.glassdoor."
+                job['id'] = s.get('data-id')
+                job['link'] = (
+                    f'https://www.glassdoor.'
                     f"{self.search_terms['region']['domain']}"
-                    f"{part_url}"
+                    f'{part_url}'
                 )
 
             except (AttributeError, IndexError):
-                job["id"] = ""
-                job["link"] = ""
+                job['id'] = ''
+                job['link'] = ''
 
-            job["query"] = self.query
-            job["provider"] = self.provider
+            job['query'] = self.query
+            job['provider'] = self.provider
 
             # key by id
-            self.scrape_data[str(job["id"])] = job
+            self.scrape_data[str(job['id'])] = job
 
         # Do not change the order of the next three statements if you want date_filter to work
 
@@ -268,4 +268,4 @@ class GlassDoorStatic(GlassDoorBase):
 
             # end and print recorded time
             end = time()
-            print(f"{self.provider} scrape job took {(end - start):.3f}s")
+            print(f'{self.provider} scrape job took {(end - start):.3f}s')

--- a/jobfunnel/glassdoor_static.py
+++ b/jobfunnel/glassdoor_static.py
@@ -1,0 +1,271 @@
+import re
+
+from bs4 import BeautifulSoup
+from concurrent.futures import ThreadPoolExecutor, wait
+from logging import info as log_info
+from math import ceil
+from requests import post
+from time import sleep, time
+
+from .jobfunnel import JobFunnel, MASTERLIST_HEADER
+from .tools.tools import filter_non_printables
+from .tools.tools import post_date_from_relative_post_age
+from .glassdoor_base import GlassDoorBase
+
+
+class GlassDoorStatic(GlassDoorBase):
+    def __init__(self, args):
+        super().__init__(args)
+        self.provider = "glassdoorstatic"
+        self.headers = {
+            "accept": "text/html,application/xhtml+xml,application/xml;"
+            "q=0.9,image/webp,*/*;q=0.8",
+            "accept-encoding": "gzip, deflate, sdch, br",
+            "accept-language": "en-GB,en-US;q=0.8,en;q=0.6",
+            "referer": "https://www.glassdoor.{0}/".format(
+                self.search_terms["region"]["domain"]
+            ),
+            "upgrade-insecure-requests": "1",
+            "user-agent": self.user_agent,
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+        }
+
+    def get_search_url(self, method="get"):
+        """gets the glassdoor search url"""
+        # form the location lookup request data
+        data = {"term": self.search_terms["region"]
+                ["city"], "maxLocationsToReturn": 10}
+
+        # form the location lookup url
+        location_url = "https://www.glassdoor.co.in/findPopularLocationAjax.htm?"
+
+        # get the location id for search location
+        location_response = self.s.post(
+            location_url, headers=self.location_headers, data=data
+        ).json()
+
+        if method == "get":
+            # @TODO implement get style for glassdoor
+            raise NotImplementedError()
+        elif method == "post":
+            # form the job search url
+            search = (
+                f"https://www.glassdoor."
+                f"{self.search_terms['region']['domain']}/Job/jobs.htm"
+            )
+
+            # form the job search data
+            data = {
+                "clickSource": "searchBtn",
+                "sc.keyword": self.query,
+                "locT": "C",
+                "locId": location_response[0]["locationId"],
+                "jobType": "",
+                "radius": self.convert_radius(self.search_terms["region"]["radius"]),
+            }
+
+            return search, data
+        else:
+            raise ValueError(f"No html method {method} exists")
+
+    def search_page_for_job_soups(self, data, page, url, job_soup_list):
+        """function that scrapes the glassdoor page for a list of job soups"""
+        log_info(f"getting glassdoor page {page} : {url}")
+
+        job = BeautifulSoup(
+            self.s.post(url, headers=self.headers,
+                        data=data).text, self.bs4_parser
+        ).find_all("li", attrs={"class", "jl"})
+        job_soup_list.extend(job)
+
+    def search_joblink_for_blurb(self, job):
+        """function that scrapes the glassdoor job link for the blurb"""
+        search = job["link"]
+        log_info(f"getting glassdoor search: {search}")
+        job_link_soup = BeautifulSoup(
+            self.s.post(
+                search, headers=self.location_headers).text, self.bs4_parser
+        )
+
+        try:
+            job["blurb"] = job_link_soup.find(
+                id="JobDescriptionContainer").text.strip()
+        except AttributeError:
+            job["blurb"] = ""
+
+        filter_non_printables(job)
+
+    # split apart above function into two so gotten blurbs can be parsed
+    # while others blurbs are being obtained
+    def get_blurb_with_delay(self, job, delay):
+        """gets blurb from glassdoor job link and sets delays for requests"""
+        sleep(delay)
+
+        search = job["link"]
+        log_info(f"delay of {delay:.2f}s, getting glassdoor search: {search}")
+
+        res = self.s.post(search, headers=self.location_headers).text
+        return job, res
+
+    def scrape(self):
+        """function that scrapes job posting from glassdoor and pickles it"""
+        log_info(f"jobfunnel glassdoor to pickle running @ {self.date_string}")
+
+        # get the search url and data
+        search, data = self.get_search_url(method="post")
+
+        # get the html data, initialize bs4 with lxml
+        request_html = self.s.post(search, headers=self.headers, data=data)
+
+        # create the soup base
+        soup_base = BeautifulSoup(request_html.text, self.bs4_parser)
+
+        # scrape total number of results, and calculate the # pages needed
+        num_res = soup_base.find(
+            "p", attrs={"class", "jobsCount"}).text.strip()
+        num_res = int(re.findall(r"(\d+)", num_res.replace(",", ""))[0])
+        log_info(
+            f"Found {num_res} glassdoor results for query=" f"{self.query}")
+
+        pages = int(ceil(num_res / self.max_results_per_page))
+
+        # init list of job soups
+        job_soup_list = []
+        # init threads
+        threads = ThreadPoolExecutor(max_workers=8)
+        # init futures list
+        fts = []
+
+        # search the pages to extract the list of job soups
+        for page in range(1, pages + 1):
+            if page == 1:
+                fts.append(  # append thread job future to futures list
+                    threads.submit(
+                        self.search_page_for_job_soups,
+                        data,
+                        page,
+                        request_html.url,
+                        job_soup_list,
+                    )
+                )
+            else:
+                # gets partial url for next page
+                part_url = (
+                    soup_base.find("li", attrs={"class", "next"}).find(
+                        "a").get("href")
+                )
+                # uses partial url to construct next page url
+                page_url = re.sub(
+                    r"_IP\d+\.",
+                    "_IP" + str(page) + ".",
+                    f"https://www.glassdoor."
+                    f"{self.search_terms['region']['domain']}"
+                    f"{part_url}",
+                )
+
+                fts.append(  # append thread job future to futures list
+                    threads.submit(
+                        self.search_page_for_job_soups,
+                        data,
+                        page,
+                        page_url,
+                        job_soup_list,
+                    )
+                )
+        wait(fts)  # wait for all scrape jobs to finish
+
+        # make a dict of job postings from the listing briefs
+        for s in job_soup_list:
+            # init dict to store scraped data
+            job = dict([(k, "") for k in MASTERLIST_HEADER])
+
+            # scrape the post data
+            job["status"] = "new"
+            try:
+                # jobs should at minimum have a title, company and location
+                job["title"] = (
+                    s.find("div", attrs={"class", "jobContainer"})
+                    .find(
+                        "a",
+                        attrs={"class", "jobLink jobInfoItem jobTitle"},
+                        recursive=False,
+                    )
+                    .text.strip()
+                )
+                job["company"] = s.find(
+                    "div", attrs={"class", "jobInfoItem jobEmpolyerName"}
+                ).text.strip()
+                job["location"] = s.get("data-job-loc")
+            except AttributeError:
+                continue
+
+            # set blurb to none for now
+            job["blurb"] = ""
+
+            try:
+                labels = s.find_all("div", attrs={"class", "jobLabel"})
+                job["tags"] = "\n".join(
+                    [l.text.strip() for l in labels if l.text.strip() != "New"]
+                )
+            except AttributeError:
+                job["tags"] = ""
+
+            try:
+                job["date"] = (
+                    s.find("div", attrs={"class", "jobLabels"})
+                    .find("span", attrs={"class", "jobLabel nowrap"})
+                    .text.strip()
+                )
+            except AttributeError:
+                job["date"] = ""
+
+            try:
+                part_url = (
+                    s.find("div", attrs={"class", "logoWrap"}).find(
+                        "a").get("href")
+                )
+                job["id"] = s.get("data-id")
+                job["link"] = (
+                    f"https://www.glassdoor."
+                    f"{self.search_terms['region']['domain']}"
+                    f"{part_url}"
+                )
+
+            except (AttributeError, IndexError):
+                job["id"] = ""
+                job["link"] = ""
+
+            job["query"] = self.query
+            job["provider"] = self.provider
+
+            # key by id
+            self.scrape_data[str(job["id"])] = job
+
+        # Do not change the order of the next three statements if you want date_filter to work
+
+        # stores references to jobs in list to be used in blurb retrieval
+        scrape_list = [i for i in self.scrape_data.values()]
+        # converts job date formats into a standard date format
+        post_date_from_relative_post_age(scrape_list)
+        # apply job pre-filter before scraping blurbs
+        super().pre_filter(self.scrape_data, self.provider)
+
+        # checks if delay is set or not, then extracts blurbs from job links
+        if self.delay_config is not None:
+            # calls super class to run delay specific threading logic
+            super().delay_threader(
+                scrape_list, self.get_blurb_with_delay, self.parse_blurb, threads
+            )
+
+        else:  # maps jobs to threads and cleans them up when done
+            # start time recording
+            start = time()
+
+            # maps jobs to threads and cleans them up when done
+            threads.map(self.search_joblink_for_blurb, scrape_list)
+            threads.shutdown()
+
+            # end and print recorded time
+            end = time()
+            print(f"{self.provider} scrape job took {(end - start):.3f}s")

--- a/tests/test_countries.py
+++ b/tests/test_countries.py
@@ -13,10 +13,11 @@ from unittest.mock import patch
 from jobfunnel.config.parser import parse_config
 from jobfunnel.indeed import Indeed
 from jobfunnel.monster import Monster
-from jobfunnel.glassdoor import GlassDoor
+from jobfunnel.glassdoor_static import GlassDoorStatic
 
 
-PROVIDERS = {'indeed': Indeed, 'monster': Monster, 'glassdoor': GlassDoor}
+PROVIDERS = {'indeed': Indeed, 'monster': Monster,
+             'glassdoorstatic': GlassDoorStatic}
 
 DOMAINS = {'America': 'com', 'Canada': 'ca'}
 
@@ -42,13 +43,15 @@ cities = random.sample(cities, test_size)
 with patch.object(sys, 'argv', ['']):
     config = parse_config()
 
+
 @pytest.mark.xfail(strict=False)
 @pytest.mark.parametrize('city', cities)
 def test_cities(city, delay=1):
     """tests american city"""
     count = 0  # a count of providers with successful test cases
     for p in config['providers']:
-        provider: Union[GlassDoor, Monster, Indeed] = PROVIDERS[p](config)
+        provider: Union[GlassDoorStatic, Monster,
+                        Indeed] = PROVIDERS[p](config)
         provider.search_terms['region']['domain'] = DOMAINS[city['country']]
         provider.search_terms['region']['province'] = city['abbreviation']
         provider.search_terms['region']['city'] = city['city']
@@ -64,7 +67,7 @@ def test_cities(city, delay=1):
 
             # get the html data, initialize bs4 with lxml
             request_html = get(search, headers=provider.headers)
-        elif isinstance(provider, GlassDoor):
+        elif isinstance(provider, GlassDoorStatic):
             try:
                 # get search url
                 search, data = provider.get_search_url(method='post')
@@ -75,7 +78,8 @@ def test_cities(city, delay=1):
             # get the html data, initialize bs4 with lxml
             request_html = post(search, headers=provider.headers, data=data)
         else:
-            raise TypeError(f'Type {type(provider)} does not match any of the providers.')
+            raise TypeError(
+                f'Type {type(provider)} does not match any of the providers.')
 
         # create the soup base
         soup_base = BeautifulSoup(request_html.text, provider.bs4_parser)
@@ -88,7 +92,7 @@ def test_cities(city, delay=1):
             where = soup_base.find(id='where')['value'].strip()
         elif isinstance(provider, Monster):
             where = soup_base.find(id='location')['value'].strip()
-        elif isinstance(provider, GlassDoor):
+        elif isinstance(provider, GlassDoorStatic):
             where = soup_base.find(id='sc.location')['value']
 
         if where.lower() == location.lower():

--- a/tests/test_countries.py
+++ b/tests/test_countries.py
@@ -19,6 +19,8 @@ from jobfunnel.glassdoor_static import GlassDoorStatic
 PROVIDERS = {'indeed': Indeed, 'monster': Monster,
              'glassdoorstatic': GlassDoorStatic}
 
+# TODO: Test GlassdoorDynamic Provider
+
 DOMAINS = {'America': 'com', 'Canada': 'ca'}
 
 cities_america = os.path.normpath(


### PR DESCRIPTION
# Glassdoor Dynamic/Static Switching

Hello everyone! Here's my code for letting the user choose between Dynamic Scraping and Static Scraping for Glassdoor

## Description

Basically, the user can now input a new command line argument that tells the Glassdoor scraper which scraping process to actually go with (the options being dynamic and static). 

To choose between dynamic or static, the user can input "-g" into the command line while running Jobfunnel and input either "dynamic" or "static" like below

`funnel -g dynamic`

## Major Code Changes

The main change I made to the base code was changing the original `glassdoor.py` into a generic `glassdoor_base.py`, that both the dynamic (`GlassDoorDynamic`) and the static (`GlassDoorStatic`) scraper can inherit from. `GlassDoorDynamic` is largely the same original glassdoor scraper, while `GlassDoorStatic` is an older version of the scraper that I took from commit `c1fb87940a20a3cc4479352740579b23a7fa9539`. 

After changing the validation options and parser to allow a new -g argument, I went into main and added a specific GLASSDOOR list for the dynamic and static child classes....

```
GLASSDOOR = {
    "static": GlassDoorStatic,
    "dynamic": GlassDoorDynamic
}
```
Then checked to see if the program was parsing the glassdoor option, and switched to the glassdoor specific providers....

```
 for p in config["providers"]:
        if "glassdoor" in p:
            provider: Union[GlassDoorDynamic,
                GlassDoorStatic] = GLASSDOOR[config["glassdoorsetting"]](config)

       else:
           provider: Union[GlassDoorBase, Monster,
                           Indeed] = PROVIDERS[p](config)
```
If the user does not input any -g option, then by default the static option for scraping glassdoor is chosen.

As of right now, this is specifically a  fix that lets the user only choose weather they want a dynamic or static scraper for _glassdoor_, hence why I chose -g as the settings options. If it comes down the line that more providers have a dynamic/static option, then in the future I can easily update this code to have a list of dynamic providers and static providers to choose from. For now, hopefully this is a good solution to let the user switch between Dynamic and Static Glassdoor scraping. 

## Context of change

Please add options that are relevant and mark any boxes that apply.

- [x] Software (software that runs on the PC)
- [ ] Library (library that runs on the PC)
- [ ] Tool (tool that assists coding development)
- [ ] Other

## Type of change

Please mark any boxes that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.

- [x] Tested on Windows 10 OS
- [ ] Tested on an isolated container(Ubuntu 18.04)

## Checklist:

Please mark any boxes that have been completed.

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
