### PR TITLE
Removed misleading ERROR level messages

### DIFF
--- a/jobfunnel/backend/scrapers/base.py
+++ b/jobfunnel/backend/scrapers/base.py
@@ -272,6 +272,7 @@ class BaseScraper(ABC, Logger):
         # Scrape the data for the post, requiring a minimum of info...
         # NOTE: if we perform a self.session.get we may get respectfully delayed
         job = None  # type: Optional[Job]
+        invalid_job = False  # type: bool
         job_init_kwargs = self.job_init_kwargs  # NOTE: faster?
         for is_get, field in self._actions_list:
 
@@ -293,6 +294,7 @@ class BaseScraper(ABC, Logger):
                         "Cancelled scraping of %s, failed JobFilter",
                         job.key_id
                     )
+                    invalid_job = True
                     break
 
             # Respectfully delay if it's configured to do so.
@@ -338,7 +340,7 @@ class BaseScraper(ABC, Logger):
                     )
 
         # Validate job fields if we got something
-        if job:
+        if job and not invalid_job:
             try:
                 job.validate()
             except Exception as err:


### PR DESCRIPTION
## Description

Many users are seeing ERROR level logs which are misleading, as this is a result of perfoming job.validate() on a job that fails our job filter, usually this one:

i.e.  `[2020-10-02 13:00:26,294] [ERROR] IndeedScraperUSAEng: Job failed validation: Description too short!`

## Context of change

This bypasses performing validation if we failed the filter.
- [x] Software (software that runs on the PC)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Travis build passes. Tested locally as well.

## Checklist:

Please mark any boxes that have been completed.

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
