### PR TITLE
tqdm invalid unicode char, changed to ascii style

### DIFF
--- a/jobfunnel/backend/scrapers/base.py
+++ b/jobfunnel/backend/scrapers/base.py
@@ -230,7 +230,7 @@ class BaseScraper(ABC, Logger):
                 )
 
             # For each job-soup object, scrape the soup into a Job (w/o desc.)
-            for future in tqdm(as_completed(futures), total=n_soups):
+            for future in tqdm(as_completed(futures), total=n_soups, ascii=True):
                 job = future.result()
                 if job:
                     # Handle inter-scraped data duplicates by key.


### PR DESCRIPTION
TQDM progress bar doesn't display unicode characters correctly on my system as per:
https://github.com/tqdm/tqdm#faq-and-known-issues

> Windows consoles often only partially support unicode and thus often require explicit ascii=True (also here). This is due to either normal-width unicode characters being incorrectly displayed as "wide", or some unicode characters not rendering.

Changed to ascii to avoid this. 