### PR TITLE
Germany_German Support

### DIFF
--- a/jobfunnel/backend/scrapers/base.py
+++ b/jobfunnel/backend/scrapers/base.py
@@ -457,3 +457,11 @@ class BaseFRFreScraper(BaseScraper):
     @property
     def locale(self) -> Locale:
         return Locale.FRANCE_FRENCH
+
+
+class BaseGEGerScraper(BaseScraper):
+    """" Localized scraper for Germany German
+    """
+    @property
+    def locale(self) -> Locale:
+        return Locale.GERMANY_GERMAN

--- a/jobfunnel/backend/scrapers/monster.py
+++ b/jobfunnel/backend/scrapers/monster.py
@@ -11,7 +11,7 @@ from requests import Session
 from jobfunnel.backend import Job
 from jobfunnel.backend.scrapers.base import (BaseCANEngScraper, BaseScraper,
                                              BaseUSAEngScraper, BaseUKEngScraper,
-                                             BaseFRFreScraper)
+                                             BaseFRFreScraper, BaseGEGerScraper)
 from jobfunnel.backend.tools.filters import JobFilter
 from jobfunnel.backend.tools.tools import calc_post_date_from_relative_str
 from jobfunnel.resources import JobField, Remoteness
@@ -406,3 +406,32 @@ class MonsterScraperFRFre(MonsterMetricRadius, BaseMonsterScraper,
             raise NotImplementedError()
         else:
             raise ValueError(f'No html method {method} exists')   
+
+class MonsterScraperGEGer(MonsterMetricRadius, BaseMonsterScraper,
+                           BaseGEGerScraper):
+    """Scrapes jobs from www.monster.de
+    """
+    def _get_search_url(self, method: Optional[str] = 'get',
+                        page: int = 1) -> str:
+        """Get the monster search url from SearchTerms
+        TODO: implement fulltime/part-time portion + company search?
+        TODO: implement POST
+        NOTE: unfortunately we cannot start on any page other than 1,
+            so the jobs displayed just scrolls forever and we will see
+            all previous jobs as we go.
+        """
+        if method == 'get':
+            return (
+                'https://www.monster.{}/jobs/search/?{}q={}&where={}'
+                    '&rad={}'.format(
+                        self.config.search_config.domain,
+                        f'page={page}&' if page > 1 else '',
+                        self.query,
+                        self.config.search_config.city.replace(' ', '-'),
+                        self._convert_radius(self.config.search_config.radius)
+                )
+            )
+        elif method == 'post':
+            raise NotImplementedError()
+        else:
+            raise ValueError(f'No html method {method} exists')

--- a/jobfunnel/backend/scrapers/registry.py
+++ b/jobfunnel/backend/scrapers/registry.py
@@ -7,11 +7,13 @@ from jobfunnel.resources import Locale, Provider
 
 from jobfunnel.backend.scrapers.indeed import (
     IndeedScraperCANEng, IndeedScraperUSAEng,
-    IndeedScraperUKEng, IndeedScraperFRFre
+    IndeedScraperUKEng, IndeedScraperFRFre,
+    IndeedScraperGEGer
 )
 from jobfunnel.backend.scrapers.monster import (
     MonsterScraperCANEng, MonsterScraperUSAEng,
-    MonsterScraperUKEng, MonsterScraperFRFre
+    MonsterScraperUKEng, MonsterScraperFRFre,
+    MonsterScraperGEGer
 )
 from jobfunnel.backend.scrapers.glassdoor import (
     GlassDoorScraperCANEng, GlassDoorScraperUSAEng,
@@ -25,6 +27,7 @@ SCRAPER_FROM_LOCALE = {
         Locale.USA_ENGLISH: IndeedScraperUSAEng,
         Locale.UK_ENGLISH: IndeedScraperUKEng,
         Locale.FRANCE_FRENCH: IndeedScraperFRFre,
+        Locale.GERMANY_GERMAN: IndeedScraperGEGer
     },
     Provider.GLASSDOOR: {
         Locale.CANADA_ENGLISH: GlassDoorScraperCANEng,
@@ -36,5 +39,6 @@ SCRAPER_FROM_LOCALE = {
         Locale.USA_ENGLISH: MonsterScraperUSAEng,
         Locale.UK_ENGLISH: MonsterScraperUKEng,
         Locale.FRANCE_FRENCH: MonsterScraperFRFre,
+        Locale.GERMANY_GERMAN:MonsterScraperGEGer
     },
 }

--- a/jobfunnel/backend/tools/tools.py
+++ b/jobfunnel/backend/tools/tools.py
@@ -17,10 +17,10 @@ from webdriver_manager.opera import OperaDriverManager
 from jobfunnel.backend import Job
 
 # Initialize list and store regex objects of date quantifiers
-HOUR_REGEX = re.compile(r'(\d+)(?:[ +]{1,3})?(?:hour|hr|heure)')
-DAY_REGEX = re.compile(r'(\d+)(?:[ +]{1,3})?(?:day|d|jour)')
-MONTH_REGEX = re.compile(r'(\d+)(?:[ +]{1,3})?month|mois')
-YEAR_REGEX = re.compile(r'(\d+)(?:[ +]{1,3})?year|annee')
+HOUR_REGEX = re.compile(r'(\d+)(?:[ +]{1,3})?(?:hour|hr|heure|Stunde)')
+DAY_REGEX = re.compile(r'(\d+)(?:[ +]{1,3})?(?:day|d|jour|Tag)')
+MONTH_REGEX = re.compile(r'(\d+)(?:[ +]{1,3})?month|mois|Monat')
+YEAR_REGEX = re.compile(r'(\d+)(?:[ +]{1,3})?year|annee|Jahr')
 RECENT_REGEX_A = re.compile(r'[tT]oday|[jJ]ust [pP]osted')
 RECENT_REGEX_B = re.compile(r'[yY]esterday')
 

--- a/jobfunnel/resources/defaults.py
+++ b/jobfunnel/resources/defaults.py
@@ -32,4 +32,5 @@ DEFAULT_DOMAIN_FROM_LOCALE = {
     Locale.USA_ENGLISH: 'com',
     Locale.UK_ENGLISH: 'co.uk',
     Locale.FRANCE_FRENCH: 'fr',
+    Locale.GERMANY_GERMAN: 'de',
 }

--- a/jobfunnel/resources/enums.py
+++ b/jobfunnel/resources/enums.py
@@ -13,7 +13,7 @@ class Locale(Enum):
     USA_ENGLISH = 3
     UK_ENGLISH = 4
     FRANCE_FRENCH = 5
-
+    GERMANY_GERMAN = 6
 
 class JobStatus(Enum):
     """Job statuses that are built-into jobfunnel

--- a/tests/config/test_search.py
+++ b/tests/config/test_search.py
@@ -33,6 +33,7 @@ def test_search_config_query_string(mocker, keywords, exp_query_str):
     (Locale.USA_ENGLISH, None, 'com'),
     (Locale.UK_ENGLISH, None, 'co.uk'),
     (Locale.FRANCE_FRENCH, None, 'fr'),
+    (Locale.GERMANY_GERMAN,None, 'de'),
     (Locale.USA_ENGLISH, 'xyz', 'xyz'),
     (None, None, None),
 ])


### PR DESCRIPTION
Duplicated changes made for previous support expansions to enable scraping on indeed and monster with ".de" domain. 

-------------------------------------------------------------------------------------------------
There are some problems though:

1. IP ban? 
After a certain threshold of listings is processed (somewhere between 25 and 75), another query would yield this output:
(Note that enabling a vpn allows for further queries)


[2021-01-28 13:55:51,824] [INFO] JobFunnel: Scraping local providers with: ['IndeedScraperGEGer', 'MonsterScraperGEGer']
[2021-01-28 13:55:53,348] [INFO] IndeedScraperGEGer: Found 2 pages of search results for query=python
[2021-01-28 13:55:53,731] [INFO] IndeedScraperGEGer: Scraped 0 job listings from search results pages
[2021-01-28 13:55:53,735] [ERROR] JobFunnel: Failed to scrape jobs for IndeedScraperGEGer
[2021-01-28 13:55:53,737] [INFO] MonsterScraperGEGer: No get() or set() will be done for Job attrs: ['REMOTENESS']
[2021-01-28 13:55:54,605] [ERROR] JobFunnel: Failed to scrape jobs for MonsterScraperGEGer
[2021-01-28 13:55:54,605] [INFO] JobFunnel: Completed all scraping, found 0 new jobs.
[2021-01-28 13:55:54,625] [WARNING] JobFunnel: No new jobs were added to CSV.

2. After the Indeed scraper is done, this error message appears. I've tried multiple province/city configurations. 

C:\Users\Lucky\Scripts>funnel load -s my_settings.yaml
[2021-01-28 13:02:27,031] [INFO] JobFunnel: Scraping local providers with: ['IndeedScraperGEGer', 'MonsterScraperGEGer']
[2021-01-28 13:02:28,423] [INFO] IndeedScraperGEGer: Found 1 pages of search results for query=python
[2021-01-28 13:02:28,987] [INFO] IndeedScraperGEGer: Scraped 23 job listings from search results pages
100%|##################################################################################| 23/23 [00:30<00:00,  1.33s/it]
[2021-01-28 13:02:59,601] [INFO] MonsterScraperGEGer: No get() or set() will be done for Job attrs: ['REMOTENESS']
[2021-01-28 13:03:00,363] [ERROR] JobFunnel: Failed to scrape jobs for MonsterScraperGEGer
Traceback (most recent call last):
  File "C:\Users\Lucky\Scripts\funnel-script.py", line 11, in <module>
    load_entry_point('JobFunnel==3.0.1', 'console_scripts', 'funnel')()
  File "C:\Users\Lucky\AppData\Roaming\Python\Python38\site-packages\jobfunnel\__main__.py", line 28, in main
    job_funnel.run()
  File "C:\Users\Lucky\AppData\Roaming\Python\Python38\site-packages\jobfunnel\backend\jobfunnel.py", line 114, in run
    scraped_jobs_dict = self.scrape()
  File "C:\Users\Lucky\AppData\Roaming\Python\Python38\site-packages\jobfunnel\backend\jobfunnel.py", line 244, in scrape
    self._check_for_inter_scraper_validity(
  File "C:\Users\Lucky\AppData\Roaming\Python\Python38\site-packages\jobfunnel\backend\jobfunnel.py", line 220, in _check_for_inter_scraper_validity
    raise ValueError(
ValueError: Inter-scraper key-id duplicate! 22e7f67c9200c7ce



